### PR TITLE
Add seeded randomness to LinkedParticles

### DIFF
--- a/apps/3D-template/src/Root.tsx
+++ b/apps/3D-template/src/Root.tsx
@@ -25,7 +25,15 @@ export const Root: React.FC = () => {
   return (
     <>
       <Composition id="y" component={TemplateMain} width={WIDTH} height={HEIGHT} fps={FPS} durationInFrames={DURATION} />
-      <Composition id="LinkedParticles" component={LinkedParticles} width={WIDTH} height={HEIGHT} fps={FPS} durationInFrames={DURATION} />
+      <Composition
+        id="LinkedParticles"
+        component={LinkedParticles}
+        width={WIDTH}
+        height={HEIGHT}
+        fps={FPS}
+        durationInFrames={DURATION}
+        defaultProps={{seed: 'LinkedParticles'}}
+      />
     </>
   );
 };

--- a/apps/3D-template/src/composites/PodcastSlides3D.tsx
+++ b/apps/3D-template/src/composites/PodcastSlides3D.tsx
@@ -10,7 +10,7 @@ export const PodcastSlides3D: React.FC<Props> = (props) => {
     <AbsoluteFill>
       {/* Live 3D background */}
       <div style={{position: 'absolute', inset: 0, zIndex: 0, pointerEvents: 'none'}}>
-        <LinkedParticles showGUI={false} />
+        <LinkedParticles showGUI={false} seed="PodcastSlides3D" />
       </div>
       {/* Scrim overlay to improve foreground readability over 3D background (slightly lighter to let animation pop) */}
       <div

--- a/apps/3D-template/src/scenes/LinkedParticles.tsx
+++ b/apps/3D-template/src/scenes/LinkedParticles.tsx
@@ -2,17 +2,27 @@ import React, {useEffect, useMemo, useRef} from 'react';
 import {useCurrentFrame, useVideoConfig} from 'remotion';
 import {LinkedParticlesSceneManager} from './LinkedParticlesSceneManager';
 
-export const LinkedParticles: React.FC<{showGUI?: boolean}> = () => {
+type LinkedParticlesProps = {
+  showGUI?: boolean;
+  seed?: string | number;
+};
+
+export const LinkedParticles: React.FC<LinkedParticlesProps> = ({
+  showGUI,
+  seed,
+}) => {
   const mountRef = useRef<HTMLDivElement>(null);
   const frame = useCurrentFrame();
-  const {fps, width, height} = useVideoConfig();
+  const videoConfig = useVideoConfig();
+  const {fps, width, height} = videoConfig;
+  const compositionId = (videoConfig as {id?: string}).id ?? 'LinkedParticles';
+  void showGUI;
 
-  const manager = useMemo(() => new LinkedParticlesSceneManager(width, height), [
-    width,
-    height,
-  ]);
+  const manager = useMemo(
+    () => new LinkedParticlesSceneManager(width, height, {compositionId, seed}),
+    [width, height, compositionId, seed],
+  );
 
-  // mount/unmount
   useEffect(() => {
     const el = mountRef.current;
     if (!el) {
@@ -26,12 +36,10 @@ export const LinkedParticles: React.FC<{showGUI?: boolean}> = () => {
     };
   }, [manager]);
 
-  // resize (frame-agnostic)
   useEffect(() => {
     manager.resize(width, height);
   }, [manager, width, height]);
 
-  // frame-driven update
   useEffect(() => {
     manager.update(frame, fps);
   }, [manager, frame, fps]);

--- a/apps/3D-template/src/utils/random.ts
+++ b/apps/3D-template/src/utils/random.ts
@@ -1,0 +1,91 @@
+export type SeedLike = string | number | boolean | null | undefined;
+
+const DEFAULT_SEED = 0x1d2f3a4b;
+
+const toUint32 = (value: SeedLike): number => {
+  if (value === undefined || value === null) {
+    return DEFAULT_SEED;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const normalized = value >>> 0;
+    return normalized === 0 ? DEFAULT_SEED : normalized;
+  }
+
+  const str = String(value);
+  let hash = 0x811c9dc5 ^ str.length;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+    hash ^= hash >>> 15;
+  }
+
+  hash = Math.imul(hash ^ (hash >>> 16), 0x85ebca6b);
+  hash ^= hash >>> 13;
+  hash = Math.imul(hash ^ (hash >>> 16), 0xc2b2ae35);
+
+  return hash >>> 0 || DEFAULT_SEED;
+};
+
+const combineSeeds = (parts: SeedLike[]): number => {
+  let seed = DEFAULT_SEED;
+  for (const part of parts) {
+    const value = toUint32(part);
+    seed ^= value + 0x9e3779b9 + ((seed << 6) >>> 0) + (seed >>> 2);
+    seed >>>= 0;
+  }
+
+  return seed >>> 0 || DEFAULT_SEED;
+};
+
+export interface SeededRandom {
+  next: () => number;
+  nextRange: (min: number, max: number) => number;
+  nextInt: (min: number, max: number) => number;
+  fork: (...parts: SeedLike[]) => SeededRandom;
+}
+
+const mulberry32 = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(state ^ (state >>> 15), state | 1);
+    t ^= Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  };
+};
+
+export const createSeededRandom = (...parts: SeedLike[]): SeededRandom => {
+  const baseSeed = combineSeeds(parts);
+  const generator = mulberry32(baseSeed);
+
+  const next = () => generator();
+  const nextRange = (min: number, max: number) => {
+    if (max < min) {
+      throw new Error('max must be greater than or equal to min');
+    }
+    return next() * (max - min) + min;
+  };
+  const nextInt = (min: number, max: number) => {
+    if (!Number.isInteger(min) || !Number.isInteger(max)) {
+      throw new Error('nextInt expects integer bounds');
+    }
+    if (max < min) {
+      throw new Error('max must be greater than or equal to min');
+    }
+    if (min === max) {
+      return min;
+    }
+    return Math.floor(nextRange(min, max + 1));
+  };
+
+  const fork = (...moreParts: SeedLike[]): SeededRandom =>
+    createSeededRandom(baseSeed, ...moreParts);
+
+  return {
+    next,
+    nextRange,
+    nextInt,
+    fork,
+  };
+};


### PR DESCRIPTION
## Summary
- add a Mulberry32-based seeded random utility for deterministic number generation
- update LinkedParticles to consume seeded randomness for galaxy textures and starfield geometry
- allow passing a seed prop from compositions and composites with sensible defaults

## Testing
- REMOTION_DISABLE_GOOGLE_FONTS=1 REMOTION_DISABLE_UPDATES_CHECK=1 pnpm --filter @studio/3d-template build:linked *(fails: network access to Google Fonts is blocked in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691551c70f5c832497a22944d7f2e0b8)