### PR TITLE
chore: remove personal config and accidentally committed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Thumbs.db
 # Remotion
 remotion-studio@*
 bash
+
+# Kamui (task management)
+.kamui/


### PR DESCRIPTION
- Add .kamui/ to .gitignore to prevent tracking personal task management files
- Remove .kamui/ directory containing personal information and local paths
- Remove accidentally committed files: bash, remotion-studio@0.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)