### PR TITLE
fix(deps): allow protobufjs build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 
 onlyBuiltDependencies:
   - esbuild
+  - protobufjs
 
 strictDepBuilds: true
 


### PR DESCRIPTION
pnpm v10 + strictDepBuilds 有効時に、protobufjs の postinstall が未許可扱いになり `pnpm install --frozen-lockfile` が失敗するのを解消します。\n\n- pnpm-workspace.yaml の `onlyBuiltDependencies` に `protobufjs` を追加\n- CI / version-check workflow のインストール失敗を防止\n