### PR TITLE
chore: adopt skill-first remotion workflow and docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+-
+
+## Skill Checklist
+
+- [ ] I applied `$remotion-best-practices`
+- [ ] I documented which rule files were used
+- [ ] I checked Composition IDs and render scripts
+- [ ] I verified `staticFile()` usage for local assets (if applicable)
+- [ ] I reviewed duration/fps/dimensions consistency
+
+## Validation
+
+- [ ] `pnpm remotion versions`
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+
+## Notes
+
+-

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -130,8 +130,9 @@ jobs:
           script: |
             const current = '${{ steps.check-updates.outputs.current }}';
             const latest = '${{ steps.check-updates.outputs.latest }}';
+            const targetTitle = `Update Remotion to ${latest}`;
 
-            // Check if issue already exists
+            // Find open Remotion dependency issues
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -139,20 +140,54 @@ jobs:
               labels: 'dependencies,remotion'
             });
 
-            const existingIssue = issues.data.find(issue =>
-              issue.title.includes('Update Remotion')
+            const remotionIssues = issues.data.filter((issue) =>
+              issue.title.startsWith('Update Remotion to ')
             );
 
-            if (existingIssue) {
-              console.log('Issue already exists:', existingIssue.html_url);
+            const exactMatch = remotionIssues.find(
+              (issue) => issue.title === targetTitle
+            );
+
+            if (exactMatch) {
+              console.log('Issue for latest version already exists:', exactMatch.html_url);
               return;
             }
 
-            // Create new issue
+            // Close stale automated issues before creating a new one.
+            for (const issue of remotionIssues) {
+              const labels = Array.isArray(issue.labels) ? issue.labels : [];
+              const automated = labels.some((label) => {
+                if (typeof label === 'string') return label === 'automated';
+                return label?.name === 'automated';
+              });
+
+              if (!automated) {
+                console.log(`Skipping non-automated issue #${issue.number}: ${issue.title}`);
+                continue;
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Closing as stale: a newer Remotion update target is available (${latest}).`
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed'
+              });
+
+              console.log(`Closed stale issue #${issue.number}: ${issue.title}`);
+            }
+
+            // Create a fresh issue for the latest version
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Update Remotion to ${latest}`,
+              title: targetTitle,
               body: `## 📦 Remotion Update Available\n\n` +
                     `A new version of Remotion is available.\n\n` +
                     `- **Current version:** ${current}\n` +

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,7 +71,7 @@ node -v && pnpm -v && ffmpeg -version
    catalog:
      react: ^18.3.1
      react-dom: ^18.3.1
-     remotion: 4.0.406
+     remotion: 4.0.x
      typescript: ^5.6.3
      # ... すべての @remotion/* パッケージ
    ```
@@ -116,16 +116,18 @@ remotion-studio-monorepo/
 
 ## ドキュメント
 
-| ガイド                                          | 説明                        |
-| ----------------------------------------------- | --------------------------- |
-| [Structure](./docs/structure.ja.md)             | モノレポ構成                |
-| [Adding Dependencies](./docs/adding-deps.ja.md) | パッケージ追加方法          |
-| [Assets Guide](./docs/assets.ja.md)             | アセット管理                |
-| [3D Notes](./docs/3d-notes.ja.md)               | Three.js / R3F セットアップ |
-| [MCP Setup](./docs/mcp-setup.ja.md)             | Claude / Codex 連携         |
-| [Upgrading](./docs/upgrading-remotion.ja.md)    | Remotion バージョン管理     |
-| [Packages](./docs/packages.ja.md)               | 利用可能なパッケージ一覧    |
-| [Troubleshooting](./docs/troubleshooting.ja.md) | よくある問題と解決方法      |
+| ガイド                                                       | 説明                        |
+| ------------------------------------------------------------ | --------------------------- |
+| [Structure](./docs/structure.ja.md)                          | モノレポ構成                |
+| [Adding Dependencies](./docs/adding-deps.ja.md)              | パッケージ追加方法          |
+| [Assets Guide](./docs/assets.ja.md)                          | アセット管理                |
+| [3D Notes](./docs/3d-notes.ja.md)                            | Three.js / R3F セットアップ |
+| [AI Skill Playbook](./docs/ai/remotion-skill-playbook.ja.md) | Skill-First 運用ルール      |
+| [Upgrading](./docs/upgrading-remotion.ja.md)                 | Remotion バージョン管理     |
+| [Packages](./docs/packages.ja.md)                            | 利用可能なパッケージ一覧    |
+| [Troubleshooting](./docs/troubleshooting.ja.md)              | よくある問題と解決方法      |
+
+> AI作業は **Skill-First** を標準とします。MCPは必要時のみ任意で利用してください（`docs/mcp-setup.ja.md`）。
 
 ## トラブルシューティング
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This monorepo uses **pnpm Catalog** to centrally manage versions of React, Remot
    catalog:
      react: ^18.3.1
      react-dom: ^18.3.1
-     remotion: 4.0.406
+     remotion: 4.0.x
      typescript: ^5.6.3
      # ... all @remotion/* packages
    ```
@@ -116,16 +116,18 @@ remotion-studio-monorepo/
 
 ## Documentation
 
-| Guide                                        | Description                    |
-| -------------------------------------------- | ------------------------------ |
-| [Structure](./docs/structure.md)             | Monorepo architecture          |
-| [Adding Dependencies](./docs/adding-deps.md) | How to add packages            |
-| [Assets Guide](./docs/assets.md)             | Managing assets                |
-| [3D Notes](./docs/3d-notes.md)               | Three.js / R3F setup           |
-| [MCP Setup](./docs/mcp-setup.md)             | Claude / Codex integration     |
-| [Upgrading](./docs/upgrading-remotion.md)    | Remotion version management    |
-| [Packages](./docs/packages.md)               | Available packages & libraries |
-| [Troubleshooting](./docs/troubleshooting.md) | Common issues & solutions      |
+| Guide                                                     | Description                    |
+| --------------------------------------------------------- | ------------------------------ |
+| [Structure](./docs/structure.md)                          | Monorepo architecture          |
+| [Adding Dependencies](./docs/adding-deps.md)              | How to add packages            |
+| [Assets Guide](./docs/assets.md)                          | Managing assets                |
+| [3D Notes](./docs/3d-notes.md)                            | Three.js / R3F setup           |
+| [AI Skill Playbook](./docs/ai/remotion-skill-playbook.md) | Skill-first workflow           |
+| [Upgrading](./docs/upgrading-remotion.md)                 | Remotion version management    |
+| [Packages](./docs/packages.md)                            | Available packages & libraries |
+| [Troubleshooting](./docs/troubleshooting.md)              | Common issues & solutions      |
+
+> AI-assisted changes should follow the **Skill-first** workflow. Use MCP only when explicitly needed (`docs/mcp-setup.md`).
 
 ## Troubleshooting
 

--- a/apps/3D-template/package.json
+++ b/apps/3D-template/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "remotion studio",
     "preview": "remotion preview",
-    "build": "remotion render src/index.ts y out/3d-template.mp4",
+    "build": "remotion render src/index.ts Main out/3d-template.mp4",
     "build:linked": "remotion render src/index.ts LinkedParticles out/linked.mp4",
     "bundle": "remotion bundle src/index.ts --out out/web"
   },

--- a/apps/3D-template/src/Root.tsx
+++ b/apps/3D-template/src/Root.tsx
@@ -41,7 +41,7 @@ export const Root: React.FC = () => {
   return (
     <>
       <Composition
-        id="y"
+        id="Main"
         component={TemplateMain}
         width={WIDTH}
         height={HEIGHT}

--- a/docs/ai/remotion-skill-playbook.ja.md
+++ b/docs/ai/remotion-skill-playbook.ja.md
@@ -1,0 +1,44 @@
+# Remotion Skill Playbook (JA)
+
+このドキュメントは、このモノレポで Remotion 関連タスクを進める際の **Skill-First** 運用ルールです。  
+標準スキルは `$remotion-best-practices` とします。
+
+## 基本方針
+
+- まずスキルを適用し、必要なルールだけ読む（全部は読まない）。
+- 変更は最小差分で行い、テンプレートと共有パッケージの整合を優先する。
+- 仕様判断はこのリポジトリの既存実装とドキュメントを一次情報にする。
+- MCP は任意。使わなくても完結できるフローを標準とする。
+
+## 標準フロー
+
+1. タスク開始時に適用スキルを明記する。  
+   例: `Using $remotion-best-practices`
+2. タスクに必要なルールを選ぶ。  
+   例: compositions / assets / calculate-metadata / transitions
+3. 実装する。
+   - Composition ID
+   - `staticFile()` 利用
+   - duration/fps/size 整合
+4. ローカル検証する。
+   - `pnpm remotion versions`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+5. PR で適用ルールをチェックリスト化して提出する。
+
+## タスク別の推奨ルール
+
+- Composition 設計: `rules/compositions.md`
+- 動的 duration/サイズ: `rules/calculate-metadata.md`
+- 画像/音声/動画: `rules/assets.md`, `rules/videos.md`, `rules/audio.md`
+- テキスト演出: `rules/text-animations.md`, `rules/measuring-text.md`
+- シーン遷移: `rules/transitions.md`, `rules/sequencing.md`
+- 3D: `rules/3d.md`
+
+## PR で最低限確認する項目
+
+- 適用したスキル/ルールが明記されている
+- 新規テンプレートで `pnpm create:project` から破綻しない
+- Remotion バージョンが catalog で揃っている
+- 既存テンプレートの build コマンドが有効

--- a/docs/ai/remotion-skill-playbook.md
+++ b/docs/ai/remotion-skill-playbook.md
@@ -1,0 +1,44 @@
+# Remotion Skill Playbook
+
+This document defines the **skill-first** workflow for Remotion tasks in this monorepo.  
+The default skill is `$remotion-best-practices`.
+
+## Core policy
+
+- Start from skills and read only the rules needed for the current task.
+- Keep changes minimal and preserve template + shared package consistency.
+- Use this repository's implementation/docs as the primary source of truth.
+- MCP is optional. The default workflow should work without it.
+
+## Standard flow
+
+1. Declare the applied skill at task start.  
+   Example: `Using $remotion-best-practices`
+2. Select relevant rules only.  
+   Example: compositions / assets / calculate-metadata / transitions
+3. Implement with explicit checks for:
+   - Composition IDs
+   - `staticFile()` usage
+   - duration/fps/size consistency
+4. Run local validation:
+   - `pnpm remotion versions`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+5. Include the applied skill/rule checklist in the PR.
+
+## Rule mapping by task
+
+- Composition design: `rules/compositions.md`
+- Dynamic duration/dimensions: `rules/calculate-metadata.md`
+- Asset handling: `rules/assets.md`, `rules/videos.md`, `rules/audio.md`
+- Text motion: `rules/text-animations.md`, `rules/measuring-text.md`
+- Scene transitions: `rules/transitions.md`, `rules/sequencing.md`
+- 3D projects: `rules/3d.md`
+
+## Minimum PR checks
+
+- Skill + rule usage is documented
+- `pnpm create:project` output remains valid
+- Remotion versions are aligned through the catalog
+- Template build commands still work

--- a/docs/upgrading-remotion.ja.md
+++ b/docs/upgrading-remotion.ja.md
@@ -24,9 +24,20 @@ pnpm upgrade:remotion
 | `pnpm upgrade:remotion --tag canary`   | dist-tag（例：`beta`、`canary`）を解決します。                |
 | `pnpm upgrade:remotion --skip-install` | 最後の `pnpm install`（ロックファイル更新）をスキップします。 |
 
+## Skill-First チェックリスト
+
+アップグレード作業時は `$remotion-best-practices` を適用し、次を確認してください。
+
+- Composition ID がビルドスクリプトと一致している
+- アセット参照が `staticFile()` ベースで統一されている
+- duration / fps / width / height の整合が取れている
+- トランジションの重なり時間を考慮して `durationInFrames` を確認した
+
 ## アップグレード後
 
 - `package.json` の変更と `pnpm-lock.yaml` をコミットします。
+- `pnpm remotion versions` で Remotion 系のバージョン一致を確認します。
+- `pnpm lint` / `pnpm typecheck` / `pnpm test` を実行します。
 - 新しいアプリを構築する際は `pnpm create:project` を再実行してください — スキャフォルダーは自動的にリポジトリルートからRemotionバージョンを同期するため、すべての新しいアプリがアップグレードされたツールチェーンと一致します。
 
 このテンプレートからスキャフォールドされた下流のリポジトリを管理している場合は、そこでも同じスクリプトを再実行して最新の状態を保ってください。

--- a/docs/upgrading-remotion.md
+++ b/docs/upgrading-remotion.md
@@ -24,9 +24,20 @@ This script:
 | `pnpm upgrade:remotion --tag canary`   | Resolve a dist-tag (e.g., `beta`, `canary`).             |
 | `pnpm upgrade:remotion --skip-install` | Skip the final `pnpm install` (lockfile update).         |
 
+## Skill-first checklist
+
+When upgrading, apply `$remotion-best-practices` and confirm:
+
+- Composition IDs match build scripts
+- Asset references consistently use `staticFile()`
+- duration / fps / width / height are aligned
+- Transition overlap is accounted for in `durationInFrames`
+
 ## After upgrading
 
 - Commit `package.json` changes + `pnpm-lock.yaml`.
+- Verify version alignment with `pnpm remotion versions`.
+- Run `pnpm lint` / `pnpm typecheck` / `pnpm test`.
 - Re-run `pnpm create:project` when building new apps — the scaffolder now syncs Remotion versions from the repo root automatically, so every fresh app matches the upgraded toolchain.
 
 If you maintain downstream repositories that were scaffolded from this template, re-run the same script there to stay up to date.


### PR DESCRIPTION
## Summary\n- add skill-first Remotion playbooks (JA/EN)\n- update README docs links to prioritize skill-first workflow over MCP\n- enhance upgrade guides with a skill-first checklist\n- add PR template with skill + validation checklist\n- improve version-check workflow to auto-close stale automated Remotion update issues\n- normalize 3D template primary composition ID from `y` to `Main`\n\n## Validation\n- pnpm remotion versions\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm --dir apps/3D-template exec remotion compositions --quiet