### PR TITLE
refactor: brush up shared utility packages

### DIFF
--- a/packages/@studio/core-types/package.json
+++ b/packages/@studio/core-types/package.json
@@ -17,6 +17,10 @@
     "lint": "eslint \"src/**/*.ts\"",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@studio/easings": "workspace:*",
+    "@studio/timing": "workspace:*"
+  },
   "peerDependencies": {
     "remotion": "^4.0.0"
   },

--- a/packages/@studio/core-types/src/animation.ts
+++ b/packages/@studio/core-types/src/animation.ts
@@ -1,7 +1,10 @@
 /**
- * Easing function type
+ * Re-export of the canonical `EasingFunction` from `@studio/easings`.
+ * Kept here so consumers of `@studio/core-types` don't need a direct
+ * dependency on `@studio/easings` when they only want the type.
  */
-export type EasingFunction = (t: number) => number;
+export type { EasingFunction } from "@studio/easings";
+import type { EasingFunction } from "@studio/easings";
 
 /**
  * Animation configuration

--- a/packages/@studio/core-types/src/timing.ts
+++ b/packages/@studio/core-types/src/timing.ts
@@ -1,11 +1,11 @@
 /**
- * Timing segment
+ * Re-export of the canonical `TimingSegment` from `@studio/timing`.
+ * The owning package is the single source of truth for this shape; this
+ * re-export lets `@studio/core-types` consumers access it without taking a
+ * direct dependency on `@studio/timing`.
  */
-export interface TimingSegment {
-  start: number;
-  duration: number;
-  label?: string;
-}
+export type { TimingSegment } from "@studio/timing";
+import type { TimingSegment } from "@studio/timing";
 
 /**
  * Timeline configuration

--- a/packages/@studio/easings/src/cubic-bezier.ts
+++ b/packages/@studio/easings/src/cubic-bezier.ts
@@ -16,7 +16,17 @@ export function cubicBezier(
   x2: number,
   y2: number,
 ): EasingFunction {
-  // Validate input
+  // Validate input: x-axis control points must be in [0, 1] for the curve
+  // to be a function of t; all four points must be finite to avoid
+  // non-convergent Newton-Raphson iteration.
+  if (
+    !Number.isFinite(x1) ||
+    !Number.isFinite(y1) ||
+    !Number.isFinite(x2) ||
+    !Number.isFinite(y2)
+  ) {
+    throw new Error("cubicBezier control points must be finite numbers");
+  }
   if (x1 < 0 || x1 > 1 || x2 < 0 || x2 > 1) {
     throw new Error("x1 and x2 must be between 0 and 1");
   }
@@ -25,10 +35,9 @@ export function cubicBezier(
     if (t <= 0) return 0;
     if (t >= 1) return 1;
 
-    // Binary search for the correct t value
+    // Newton-Raphson iteration: solve sampleCurveX(mid) === t for mid,
+    // then return sampleCurveY(mid).
     let mid = t;
-
-    // Newton-Raphson iteration for better performance
     for (let i = 0; i < 8; i++) {
       const x = sampleCurveX(mid, x1, x2);
       const slope = sampleCurveDerivativeX(mid, x1, x2);
@@ -44,27 +53,19 @@ export function cubicBezier(
 }
 
 /**
- * Sample the X value of the cubic bezier curve at time t
+ * Sample the X value of the cubic bezier curve at time t.
+ * P0 = (0, 0) and P3 = (1, 1) are fixed, so those terms collapse.
  */
 function sampleCurveX(t: number, x1: number, x2: number): number {
-  return (
-    (1 - t) ** 3 * 0 +
-    3 * (1 - t) ** 2 * t * x1 +
-    3 * (1 - t) * t ** 2 * x2 +
-    t ** 3 * 1
-  );
+  return 3 * (1 - t) ** 2 * t * x1 + 3 * (1 - t) * t ** 2 * x2 + t ** 3;
 }
 
 /**
- * Sample the Y value of the cubic bezier curve at time t
+ * Sample the Y value of the cubic bezier curve at time t.
+ * P0 = (0, 0) and P3 = (1, 1) are fixed, so those terms collapse.
  */
 function sampleCurveY(t: number, y1: number, y2: number): number {
-  return (
-    (1 - t) ** 3 * 0 +
-    3 * (1 - t) ** 2 * t * y1 +
-    3 * (1 - t) * t ** 2 * y2 +
-    t ** 3 * 1
-  );
+  return 3 * (1 - t) ** 2 * t * y1 + 3 * (1 - t) * t ** 2 * y2 + t ** 3;
 }
 
 /**

--- a/packages/@studio/easings/src/utils.ts
+++ b/packages/@studio/easings/src/utils.ts
@@ -25,16 +25,16 @@ export function mirrorEasing(easing: EasingFunction): EasingFunction {
 
 /**
  * Create a stepped easing function
- * @param steps - Number of steps
+ * @param stepCount - Number of steps
  * @param jumpStart - Whether to jump at the start of each step
  * @returns Stepped easing function
  */
 export function steps(
-  steps: number,
+  stepCount: number,
   jumpStart: boolean = false,
 ): EasingFunction {
   return (t: number) => {
-    const stepSize = 1 / steps;
+    const stepSize = 1 / stepCount;
     const step = Math.floor(t / stepSize);
     const offset = jumpStart ? 1 : 0;
     return Math.min((step + offset) * stepSize, 1);

--- a/packages/@studio/hooks/README.md
+++ b/packages/@studio/hooks/README.md
@@ -90,7 +90,7 @@ const { isStart, isEnd } = useVideoEdges(10); // within 10 frames of edges
 
 - `useDelayedMount(startFrame)`: Delay content until frame
 - `useFrameRange(startFrame, endFrame)`: Show content within range
-- `useDelayedMountByTime(startSeconds, fps)`: Delay based on time
+- `useDelayedMountByTime(startSeconds)`: Delay based on time (reads `fps` from `useVideoConfig`)
 
 ### useVideoMetadata
 

--- a/packages/@studio/hooks/package.json
+++ b/packages/@studio/hooks/package.json
@@ -14,8 +14,13 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@studio/timing": "workspace:*"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/@studio/hooks/src/useDelayedMount.ts
+++ b/packages/@studio/hooks/src/useDelayedMount.ts
@@ -1,4 +1,5 @@
-import { useCurrentFrame } from "remotion";
+import { useCurrentFrame, useVideoConfig } from "remotion";
+import { secondsToFrames } from "@studio/timing";
 
 /**
  * Delay mounting of a component until a specific frame
@@ -22,15 +23,13 @@ export function useFrameRange(startFrame: number, endFrame: number): boolean {
 }
 
 /**
- * Delay mounting based on time in seconds
+ * Delay mounting based on time in seconds. `fps` is read from the current
+ * Remotion video config, matching the style of `useTimeProgress`.
  * @param startSeconds - Time in seconds to start showing content
- * @param fps - Frames per second
  * @returns True if content should be shown
  */
-export function useDelayedMountByTime(
-  startSeconds: number,
-  fps: number,
-): boolean {
+export function useDelayedMountByTime(startSeconds: number): boolean {
   const frame = useCurrentFrame();
-  return frame >= startSeconds * fps;
+  const { fps } = useVideoConfig();
+  return frame >= secondsToFrames(startSeconds, fps);
 }

--- a/packages/@studio/hooks/src/useFrameProgress.ts
+++ b/packages/@studio/hooks/src/useFrameProgress.ts
@@ -1,4 +1,5 @@
 import { useCurrentFrame, useVideoConfig } from "remotion";
+import { getProgress, secondsToFrames } from "@studio/timing";
 
 /**
  * Get animation progress (0-1) for current frame within a range
@@ -8,11 +9,7 @@ import { useCurrentFrame, useVideoConfig } from "remotion";
  */
 export function useFrameProgress(startFrame: number, endFrame: number): number {
   const frame = useCurrentFrame();
-
-  if (frame <= startFrame) return 0;
-  if (frame >= endFrame) return 1;
-
-  return (frame - startFrame) / (endFrame - startFrame);
+  return getProgress(frame, startFrame, endFrame);
 }
 
 /**
@@ -28,13 +25,10 @@ export function useTimeProgress(
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
 
-  const startFrame = startSeconds * fps;
-  const endFrame = startFrame + durationSeconds * fps;
+  const startFrame = secondsToFrames(startSeconds, fps);
+  const endFrame = startFrame + secondsToFrames(durationSeconds, fps);
 
-  if (frame <= startFrame) return 0;
-  if (frame >= endFrame) return 1;
-
-  return (frame - startFrame) / (endFrame - startFrame);
+  return getProgress(frame, startFrame, endFrame);
 }
 
 /**
@@ -45,5 +39,5 @@ export function useVideoProgress(): number {
   const frame = useCurrentFrame();
   const { durationInFrames } = useVideoConfig();
 
-  return Math.min(frame / durationInFrames, 1);
+  return getProgress(frame, 0, durationInFrames);
 }

--- a/packages/@studio/hooks/src/useSegment.ts
+++ b/packages/@studio/hooks/src/useSegment.ts
@@ -1,9 +1,16 @@
 import { useCurrentFrame } from "remotion";
+import {
+  getLocalFrame,
+  getSegmentEnd,
+  isInSegment,
+  type TimingSegment,
+} from "@studio/timing";
 
-export interface SegmentConfig {
-  start: number;
-  duration: number;
-}
+/**
+ * Back-compat alias for the canonical `TimingSegment` type from
+ * `@studio/timing`. Existing consumers can keep referring to `SegmentConfig`.
+ */
+export type SegmentConfig = TimingSegment;
 
 export interface SegmentState {
   isActive: boolean;
@@ -18,11 +25,19 @@ export interface SegmentState {
  */
 export function useSegment(segment: SegmentConfig): SegmentState {
   const frame = useCurrentFrame();
-  const endFrame = segment.start + segment.duration;
+  const isActive = isInSegment(frame, segment);
+  const localFrame = getLocalFrame(frame, segment);
 
-  const isActive = frame >= segment.start && frame < endFrame;
-  const localFrame = isActive ? frame - segment.start : -1;
-  const progress = isActive ? localFrame / segment.duration : 0;
+  // Progress is 0 before the segment starts, 1 after it ends, and a linear
+  // ramp while active. Guard against a zero-duration segment to avoid NaN.
+  let progress: number;
+  if (isActive) {
+    progress = segment.duration > 0 ? localFrame / segment.duration : 1;
+  } else if (frame >= getSegmentEnd(segment)) {
+    progress = 1;
+  } else {
+    progress = 0;
+  }
 
   return {
     isActive,
@@ -38,9 +53,5 @@ export function useSegment(segment: SegmentConfig): SegmentState {
  */
 export function useActiveSegment(segments: SegmentConfig[]): number {
   const frame = useCurrentFrame();
-
-  return segments.findIndex(
-    (segment) =>
-      frame >= segment.start && frame < segment.start + segment.duration,
-  );
+  return segments.findIndex((segment) => isInSegment(frame, segment));
 }

--- a/packages/@studio/hooks/test/useDelayedMount.test.ts
+++ b/packages/@studio/hooks/test/useDelayedMount.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useCurrentFrame, useVideoConfig } from "remotion";
+import {
+  useDelayedMount,
+  useFrameRange,
+  useDelayedMountByTime,
+} from "../src/useDelayedMount";
+
+vi.mock("remotion", () => ({
+  useCurrentFrame: vi.fn(),
+  useVideoConfig: vi.fn(),
+}));
+
+const mockFrame = (f: number) => {
+  vi.mocked(useCurrentFrame).mockReturnValue(f);
+};
+
+const mockFps = (fps: number) => {
+  vi.mocked(useVideoConfig).mockReturnValue({
+    fps,
+    durationInFrames: 1000,
+    width: 1920,
+    height: 1080,
+    id: "test",
+    defaultProps: {},
+    props: {},
+    defaultCodec: "h264",
+    defaultOutName: "out",
+    defaultVideoImageFormat: "jpeg",
+    defaultPixelFormat: "yuv420p",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+};
+
+describe("useDelayedMount module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useDelayedMount", () => {
+    it("is false before the start frame", () => {
+      mockFrame(9);
+      expect(useDelayedMount(10)).toBe(false);
+    });
+
+    it("is true at the start frame", () => {
+      mockFrame(10);
+      expect(useDelayedMount(10)).toBe(true);
+    });
+
+    it("is true after the start frame", () => {
+      mockFrame(100);
+      expect(useDelayedMount(10)).toBe(true);
+    });
+  });
+
+  describe("useFrameRange", () => {
+    it("is false before the range", () => {
+      mockFrame(5);
+      expect(useFrameRange(10, 20)).toBe(false);
+    });
+
+    it("is true inside the range", () => {
+      mockFrame(15);
+      expect(useFrameRange(10, 20)).toBe(true);
+    });
+
+    it("is false at the end frame (exclusive)", () => {
+      mockFrame(20);
+      expect(useFrameRange(10, 20)).toBe(false);
+    });
+
+    it("is false after the range", () => {
+      mockFrame(25);
+      expect(useFrameRange(10, 20)).toBe(false);
+    });
+  });
+
+  describe("useDelayedMountByTime", () => {
+    it("reads fps from useVideoConfig and converts seconds to frames", () => {
+      mockFrame(29);
+      mockFps(30);
+      expect(useDelayedMountByTime(1)).toBe(false);
+
+      mockFrame(30);
+      mockFps(30);
+      expect(useDelayedMountByTime(1)).toBe(true);
+    });
+
+    it("works with non-integer seconds", () => {
+      mockFrame(45);
+      mockFps(30);
+      // 1.5s @ 30fps = frame 45
+      expect(useDelayedMountByTime(1.5)).toBe(true);
+
+      mockFrame(44);
+      mockFps(30);
+      expect(useDelayedMountByTime(1.5)).toBe(false);
+    });
+  });
+});

--- a/packages/@studio/hooks/test/useFrameProgress.test.ts
+++ b/packages/@studio/hooks/test/useFrameProgress.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useCurrentFrame, useVideoConfig } from "remotion";
+import {
+  useFrameProgress,
+  useTimeProgress,
+  useVideoProgress,
+} from "../src/useFrameProgress";
+
+vi.mock("remotion", () => ({
+  useCurrentFrame: vi.fn(),
+  useVideoConfig: vi.fn(),
+}));
+
+const mockFrame = (f: number) => {
+  vi.mocked(useCurrentFrame).mockReturnValue(f);
+};
+
+const mockConfig = (config: {
+  fps?: number;
+  durationInFrames?: number;
+  width?: number;
+  height?: number;
+}) => {
+  vi.mocked(useVideoConfig).mockReturnValue({
+    fps: 30,
+    durationInFrames: 100,
+    width: 1920,
+    height: 1080,
+    id: "test",
+    defaultProps: {},
+    props: {},
+    defaultCodec: "h264",
+    defaultOutName: "out",
+    defaultVideoImageFormat: "jpeg",
+    defaultPixelFormat: "yuv420p",
+    ...config,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+};
+
+describe("useFrameProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useFrameProgress", () => {
+    it("returns 0 before the range", () => {
+      mockFrame(-5);
+      expect(useFrameProgress(0, 100)).toBe(0);
+    });
+
+    it("returns 0 at the start of the range", () => {
+      mockFrame(0);
+      expect(useFrameProgress(0, 100)).toBe(0);
+    });
+
+    it("returns 0.5 at the midpoint", () => {
+      mockFrame(50);
+      expect(useFrameProgress(0, 100)).toBe(0.5);
+    });
+
+    it("returns 1 at the end of the range", () => {
+      mockFrame(100);
+      expect(useFrameProgress(0, 100)).toBe(1);
+    });
+
+    it("returns 1 after the range", () => {
+      mockFrame(150);
+      expect(useFrameProgress(0, 100)).toBe(1);
+    });
+  });
+
+  describe("useTimeProgress", () => {
+    it("converts seconds to frames via fps and computes progress", () => {
+      // fps=30, start=1s => frame 30, duration=2s => ends at frame 90
+      mockFrame(60);
+      mockConfig({ fps: 30 });
+      expect(useTimeProgress(1, 2)).toBe(0.5);
+    });
+
+    it("returns 0 before the time range", () => {
+      mockFrame(10);
+      mockConfig({ fps: 30 });
+      expect(useTimeProgress(1, 2)).toBe(0);
+    });
+
+    it("returns 1 after the time range", () => {
+      mockFrame(200);
+      mockConfig({ fps: 30 });
+      expect(useTimeProgress(1, 2)).toBe(1);
+    });
+  });
+
+  describe("useVideoProgress", () => {
+    it("returns 0 at frame 0", () => {
+      mockFrame(0);
+      mockConfig({ durationInFrames: 100 });
+      expect(useVideoProgress()).toBe(0);
+    });
+
+    it("returns 0.5 halfway through the video", () => {
+      mockFrame(50);
+      mockConfig({ durationInFrames: 100 });
+      expect(useVideoProgress()).toBe(0.5);
+    });
+
+    it("returns 1 at the last frame", () => {
+      mockFrame(100);
+      mockConfig({ durationInFrames: 100 });
+      expect(useVideoProgress()).toBe(1);
+    });
+  });
+});

--- a/packages/@studio/hooks/test/useSegment.test.ts
+++ b/packages/@studio/hooks/test/useSegment.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useCurrentFrame } from "remotion";
+import { useSegment, useActiveSegment } from "../src/useSegment";
+
+vi.mock("remotion", () => ({
+  useCurrentFrame: vi.fn(),
+  useVideoConfig: vi.fn(),
+}));
+
+const mockFrame = (f: number) => {
+  vi.mocked(useCurrentFrame).mockReturnValue(f);
+};
+
+describe("useSegment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useSegment", () => {
+    const segment = { start: 10, duration: 20 }; // active frames [10, 30)
+
+    it("is inactive before the segment starts, progress 0", () => {
+      mockFrame(5);
+      const state = useSegment(segment);
+      expect(state.isActive).toBe(false);
+      expect(state.localFrame).toBe(-1);
+      expect(state.progress).toBe(0);
+    });
+
+    it("is active at the start with progress 0", () => {
+      mockFrame(10);
+      const state = useSegment(segment);
+      expect(state.isActive).toBe(true);
+      expect(state.localFrame).toBe(0);
+      expect(state.progress).toBe(0);
+    });
+
+    it("is active mid-segment with fractional progress", () => {
+      mockFrame(20);
+      const state = useSegment(segment);
+      expect(state.isActive).toBe(true);
+      expect(state.localFrame).toBe(10);
+      expect(state.progress).toBe(0.5);
+    });
+
+    it("is inactive past the segment, progress 1", () => {
+      mockFrame(50);
+      const state = useSegment(segment);
+      expect(state.isActive).toBe(false);
+      expect(state.localFrame).toBe(-1);
+      expect(state.progress).toBe(1);
+    });
+
+    it("handles a zero-duration segment without NaN", () => {
+      mockFrame(10);
+      const state = useSegment({ start: 10, duration: 0 });
+      expect(Number.isNaN(state.progress)).toBe(false);
+    });
+  });
+
+  describe("useActiveSegment", () => {
+    const segments = [
+      { start: 0, duration: 10 },
+      { start: 10, duration: 10 },
+      { start: 20, duration: 10 },
+    ];
+
+    it("returns the index of the active segment", () => {
+      mockFrame(5);
+      expect(useActiveSegment(segments)).toBe(0);
+      mockFrame(15);
+      expect(useActiveSegment(segments)).toBe(1);
+      mockFrame(25);
+      expect(useActiveSegment(segments)).toBe(2);
+    });
+
+    it("returns -1 when no segment matches", () => {
+      mockFrame(100);
+      expect(useActiveSegment(segments)).toBe(-1);
+    });
+  });
+});

--- a/packages/@studio/hooks/test/useVideoMetadata.test.ts
+++ b/packages/@studio/hooks/test/useVideoMetadata.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useCurrentFrame, useVideoConfig } from "remotion";
+import { useVideoMetadata, useVideoEdges } from "../src/useVideoMetadata";
+
+vi.mock("remotion", () => ({
+  useCurrentFrame: vi.fn(),
+  useVideoConfig: vi.fn(),
+}));
+
+const mockFrame = (f: number) => {
+  vi.mocked(useCurrentFrame).mockReturnValue(f);
+};
+
+const mockConfig = (config: {
+  fps?: number;
+  durationInFrames?: number;
+  width?: number;
+  height?: number;
+}) => {
+  vi.mocked(useVideoConfig).mockReturnValue({
+    fps: 30,
+    durationInFrames: 300,
+    width: 1920,
+    height: 1080,
+    id: "test",
+    defaultProps: {},
+    props: {},
+    defaultCodec: "h264",
+    defaultOutName: "out",
+    defaultVideoImageFormat: "jpeg",
+    defaultPixelFormat: "yuv420p",
+    ...config,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+};
+
+describe("useVideoMetadata module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useVideoMetadata", () => {
+    it("returns the derived metadata for the current frame", () => {
+      mockFrame(150);
+      mockConfig({
+        fps: 30,
+        durationInFrames: 300,
+        width: 1920,
+        height: 1080,
+      });
+
+      const meta = useVideoMetadata();
+      expect(meta.currentFrame).toBe(150);
+      expect(meta.currentTime).toBe(5);
+      expect(meta.totalFrames).toBe(300);
+      expect(meta.totalDuration).toBe(10);
+      expect(meta.fps).toBe(30);
+      expect(meta.width).toBe(1920);
+      expect(meta.height).toBe(1080);
+      expect(meta.progress).toBe(0.5);
+    });
+
+    it("clamps progress to 1 at the end of the video", () => {
+      mockFrame(300);
+      mockConfig({ durationInFrames: 300 });
+      expect(useVideoMetadata().progress).toBe(1);
+    });
+  });
+
+  describe("useVideoEdges", () => {
+    it("detects the start edge", () => {
+      mockFrame(5);
+      mockConfig({ durationInFrames: 300 });
+      const edges = useVideoEdges(10);
+      expect(edges.isStart).toBe(true);
+      expect(edges.isEnd).toBe(false);
+    });
+
+    it("detects the end edge", () => {
+      mockFrame(295);
+      mockConfig({ durationInFrames: 300 });
+      const edges = useVideoEdges(10);
+      expect(edges.isStart).toBe(false);
+      expect(edges.isEnd).toBe(true);
+    });
+
+    it("reports neither edge in the middle of the video", () => {
+      mockFrame(150);
+      mockConfig({ durationInFrames: 300 });
+      const edges = useVideoEdges(10);
+      expect(edges.isStart).toBe(false);
+      expect(edges.isEnd).toBe(false);
+    });
+  });
+});

--- a/packages/@studio/timing/src/frame-utils.ts
+++ b/packages/@studio/timing/src/frame-utils.ts
@@ -41,15 +41,11 @@ export function frameToMs(frame: number, fps: number): number {
 /**
  * Clamp a frame number within a valid range
  * @param frame - Current frame
- * @param min - Minimum frame (default: 0)
+ * @param min - Minimum frame
  * @param max - Maximum frame
  * @returns Clamped frame number
  */
-export function clampFrame(
-  frame: number,
-  min: number = 0,
-  max: number,
-): number {
+export function clampFrame(frame: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, frame));
 }
 

--- a/packages/@studio/timing/src/timing-helpers.ts
+++ b/packages/@studio/timing/src/timing-helpers.ts
@@ -4,6 +4,8 @@
 export interface TimingSegment {
   start: number;
   duration: number;
+  /** Optional human-readable label for the segment */
+  label?: string;
 }
 
 /**

--- a/packages/@studio/timing/test/frame-utils.test.ts
+++ b/packages/@studio/timing/test/frame-utils.test.ts
@@ -55,5 +55,13 @@ describe("frame-utils", () => {
       expect(getProgress(-10, 0, 100)).toBe(0);
       expect(getProgress(150, 0, 100)).toBe(1);
     });
+
+    it("should handle zero-length ranges without returning NaN", () => {
+      // start === end: frame before/at the point is 0, after is 1.
+      expect(getProgress(0, 5, 5)).toBe(0);
+      expect(getProgress(5, 5, 5)).toBe(0);
+      expect(getProgress(10, 5, 5)).toBe(1);
+      expect(Number.isNaN(getProgress(7, 5, 5))).toBe(false);
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,12 @@ importers:
 
   packages/@studio/core-types:
     dependencies:
+      "@studio/easings":
+        specifier: workspace:*
+        version: link:../easings
+      "@studio/timing":
+        specifier: workspace:*
+        version: link:../timing
       remotion:
         specifier: ^4.0.0
         version: 4.0.351(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -522,6 +528,9 @@ importers:
 
   packages/@studio/hooks:
     dependencies:
+      "@studio/timing":
+        specifier: workspace:*
+        version: link:../timing
       react:
         specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1


### PR DESCRIPTION
## Summary

`packages/@studio/*` 配下の汎用ユーティリティ層をブラッシュアップ。型の重複削除・ロジックの再利用・軽微なバグ修正・`@studio/hooks` の単体テスト追加を1コミットにまとめた。

## Changes

**`@studio/timing`**
- `clampFrame(frame, min, max)`: デフォルト引数が必須引数の前にあった問題を修正、両方必須に
- `TimingSegment` に `label?: string` を追加（非破壊）
- `getProgress` のゼロ長レンジに対する回帰テストを追加

**`@studio/easings`**
- `cubicBezier`: 古い "binary search" コメントを削除、`Number.isFinite` バリデーションを追加（NaN 入力で無限ループしないように）
- `sampleCurveX/Y` のデッド項（`(1-t)^3 * 0` / `t^3 * 1`）を削除
- `utils.steps` の引数 `steps` を `stepCount` にリネーム（関数名シャドー解消）

**`@studio/core-types`**
- 重複していた `EasingFunction` / `TimingSegment` のローカル定義を削除し、所有パッケージ（`@studio/easings` / `@studio/timing`）からの re-export に置換。単一のソース・オブ・トゥルース化
- workspace 依存を追加

**`@studio/hooks`**
- `@studio/timing` を依存に追加し、`useFrameProgress` / `useTimeProgress` / `useVideoProgress` / `useSegment` / `useActiveSegment` / `useDelayedMountByTime` をすべて `getProgress` / `isInSegment` / `getLocalFrame` / `secondsToFrames` 経由に統一
- `useDelayedMountByTime` から冗長な `fps` 引数を削除し、`useVideoConfig()` から取得（`useTimeProgress` と同じスタイル）
- `useSegment` の `progress` セマンティクスを修正: セグメント前は 0、後は 1（以前はどちらも 0）
- `SegmentConfig` は `TimingSegment` の後方互換エイリアスに
- **32 の新規ユニットテスト** を `test/` に追加（`remotion` をモック）
- `test` / `test:watch` スクリプトを追加

## Impact

唯一の外部利用者は `apps/examples/animations-showcase` のみで、変更した API シグネチャ（`clampFrame` / `useDelayedMountByTime`）も内部型の移動も未使用。既存の呼び出し箇所への影響なし。

## Test plan

- [x] `pnpm test` — **58 passing**（32 新規 + 26 既存）
- [x] `pnpm typecheck` — **10/10 turbo タスク成功**
- [x] `pnpm build:packages` — 全5パッケージ成功
- [x] `apps/examples/animations-showcase` の `tsc --noEmit` — clean
- [x] `pnpm lint`（変更4パッケージ）— clean
- [x] `prettier --check`（17ファイル）— clean

https://claude.ai/code/session_01LDkuPFVnSe5KGHQc1KhYBG